### PR TITLE
Register SvgImageFile via Image.register_*

### DIFF
--- a/pillow_svg/SvgImagePlugin.py
+++ b/pillow_svg/SvgImagePlugin.py
@@ -560,8 +560,7 @@ def draw_svg_file(file: str, imagedraw: ImageDraw.ImageDraw, imagesize: Tuple[in
 
 
 def _accept(prefix):
-    prefixStr = prefix.decode("utf-8")
-    return "<?xml" in prefixStr or "<svg " in prefixStr or "<!DOC" in prefixStr
+    return b"<?xml" in prefix or b"<svg" in prefix or b"<!DOC" in prefix
 
 
 class SvgImageFile(ImageFile.ImageFile):
@@ -595,3 +594,15 @@ class SvgImageFile(ImageFile.ImageFile):
         self.tile = [("SVGXML", (0, 0) + self.size, 0, (None, self, None, None, svg_default_background))]
 
 
+# ---------------------------------------------------------------------
+# Registry stuff
+
+Image.register_open(SvgImageFile.format, SvgImageFile, _accept)
+# Image.register_save(SvgImageFile.format, _save)  # TODO Where save?
+
+Image.register_decoder(SvgImageFile.format, SvgDecoder)
+# Image.register_encoder(SvgImageFile.format, SvgEncoder)  # TODO Where Encoder?
+
+Image.register_extensions(SvgImageFile.format, [".svg"])
+
+Image.register_mime(SvgImageFile.format, "image/svg+xml")

--- a/tests/test_file_svg.py
+++ b/tests/test_file_svg.py
@@ -38,3 +38,20 @@ def test_quick():
         assert im.size == (24, 24)
         assert_image_similar(im, compare, 1)
 
+
+def test_open_svg_file():
+    for fn in ['rectangle']:
+        Image.open(os.path.join(SVG_DIR, fn + '.svg'))
+
+
+def test_registry():
+    assert 'SVG' in Image.ID
+    assert '.svg' in Image.EXTENSION
+    assert 'SVG' in Image.MIME
+    assert Image.MIME['SVG'] == 'image/svg+xml'
+    # TODO Where save?
+    # assert 'SVG' in Image.SAVE
+
+    assert 'SVG' in Image.DECODERS
+    # TODO Where Encoder?
+    # assert 'SVG' in Image.ENCODERS


### PR DESCRIPTION
Hi,
I'm developing a small Django website and we want to allow SVG uploads to ImageField which brought me to this project.

I had some issue uploading an SVG image because `SvgImageFile` wasn't registered via `Image.register_open` and similar methods. This is adding such registration and upload via Django works smoothly with just importing `SvgImagePlugin`.

Let me know your thoughts.
Thanks!